### PR TITLE
Improve consent by facility requirement

### DIFF
--- a/src/fauna/fql/test/TestConsent.fql
+++ b/src/fauna/fql/test/TestConsent.fql
@@ -1,20 +1,20 @@
 let patient = Patient.byLastAndFirstName(
   'Schmitt', 'Carine'
-).first()
+).first()!
 let practitioner = Practitioner.byLastAndFirstName(
   'Thompson', 'Steve'
-).first()
+).first()!
 
 let concentDocument = Record.create({
   patient: patient,
-  facility: practitioner!.facility,
+  facility: practitioner.facility,
   name: "Informed Concent",
   description: "This record signifies the patient has consented to treatment"
 })
 
 Consent.create({
-  record: record,
-  patient: patient, 
-  facility: practitioner.facility
+  patient: patient,
+  facility: practitioner.facility,
+  purpose: "Treatment"
 })
 

--- a/src/fauna/fsl/PatientRole.fsl
+++ b/src/fauna/fsl/PatientRole.fsl
@@ -1,4 +1,3 @@
-
 role Patient {
 
   membership Patient 
@@ -7,34 +6,28 @@ role Patient {
     // may read thier own medical records but not alter them
     read {
       predicate (
-        (record) => { record.patient == Query.identity() }
+        (record) => record.patient == Query.identity()
       )
     }
   }
 
   privileges Consent {
-    
-    // A patient may only create or delete thier own consents
+    // A patient may only read, create, or delete thier own consents
     create {
       predicate (
-        (consent) => { 
-          consent.record.patient == Query.identity() 
-          && consent.patient == Query.identity()
-        }
+        (consent) => consent.patient == Query.identity()
       )
     }
 
     read {
       predicate (
-        (consent) => { consent.patient == Query.identity() }
+        (consent) => consent.patient == Query.identity()
       )
     }
 
     delete {
       predicate (
-        (consent) => {
-          consent.patient == Query.identity()  
-        }
+        (consent) => consent.patient == Query.identity()
       ) 
     }
   }

--- a/src/fauna/fsl/ResearcherRole.fsl
+++ b/src/fauna/fsl/ResearcherRole.fsl
@@ -8,7 +8,10 @@ role Researcher {
     read {
       predicate (
         (record) => {
-          Consent.byRecordAndFacility(record, Query.identity()!.facility).first() != null
+          Consent.byPatientAndFacility(
+            record.patient,
+            Query.identity()!.facility
+          ).nonEmpty()
         }
       )
     }

--- a/src/fauna/fsl/collections.fsl
+++ b/src/fauna/fsl/collections.fsl
@@ -91,29 +91,31 @@ collection Record {
 }
 
 collection Event {
-  patient: Ref<Patient>
   record: Ref<Record>
   accessor: Ref<Researcher> | Ref<Practitioner>
   type: "Export" | "Disclosure"
   purpose: "Treatment" | "Research"
 
   history_days 0
+
+  migrations {
+    drop .patient
+  }
 }
 
 collection Consent {
-  record: Ref<Record>
   patient: Ref<Patient>
   facility: Ref<Facility>
+  purpose: "Treatment" | "Research" = "Treatment"
 
-  unique [ .record, .facility ]
-  unique [ .patient, .facility ]
+  unique [ .patient, .facility, .purpose ]
 
   index byPatient {
     terms [.patient]
   }
 
-  index byRecordAndFacility {
-    terms [.record, .facility]
+  index byPatientAndFacility {
+    terms [.patient, .facility]
   }
 
   history_days 0
@@ -122,5 +124,7 @@ collection Consent {
     add .record
     add .patient
     add .facility
+    add .purpose
+    drop .record
   }
 }

--- a/src/fauna/fsl/function.fsl
+++ b/src/fauna/fsl/function.fsl
@@ -11,7 +11,6 @@ function AccessRecord (
   }
 
   Event.create({
-    patient: record!.patient,
     record: record,
     accessor: accessor,
     type: type,


### PR DESCRIPTION
I think there's an issue with the consent by facility requirement. The current consent record has 2 unique constraints:

```
unique [ .record, .facility ]
unique [ .patient, .facility ]
```

That means that a patient can't give more than 1 consent to a facility. That'll not demo well for the Mr. Brown's use case. I think we should have patients giving consent to facilities for a given purpose. For example: Mr. Brown has given the facility access to his records for the purpose of treatment but not for research. That way we can demo researchers not having access until Mr. Brown adds additional consent.

I did a small clean up as well by removing `.patient` from `Event` since it can be retrieved by the `.record.patient`.