### PR TITLE
Add badgedIn field to practitioner and researcher

### DIFF
--- a/src/fauna/fsl/PractitionerRole.fsl
+++ b/src/fauna/fsl/PractitionerRole.fsl
@@ -1,6 +1,8 @@
 role Practitioner {
   
-  membership Practitioner 
+  membership Practitioner {
+    predicate (practitioner => practitioner.badgedIn)
+  }
 
   privileges Record {
     

--- a/src/fauna/fsl/ResearcherRole.fsl
+++ b/src/fauna/fsl/ResearcherRole.fsl
@@ -1,6 +1,8 @@
 role Researcher {
 
-  membership Researcher
+  membership Researcher {
+    predicate (practitioner => practitioner.badgedIn)
+  }
 
   privileges Record {
     // an insurer can read medical records only if the patient has given

--- a/src/fauna/fsl/collections.fsl
+++ b/src/fauna/fsl/collections.fsl
@@ -31,12 +31,18 @@ collection Practitioner {
     country: String
   }
   facility: Ref<Facility>
+  badgedIn: Boolean = true
 
   index byLastAndFirstName {
      terms [ .name.last, .name.first ]
   }
   
   history_days 0
+
+  migrations {
+    add .badgedIn
+    backfill .badgedIn = true
+  }
 }
 
 collection Researcher {
@@ -52,6 +58,7 @@ collection Researcher {
     country: String
   }
   facility: Ref<Facility>
+  badgedIn: Boolean = true
 
   index byLastAndFirstName {
      terms [ .name.last, .name.first ]
@@ -61,6 +68,8 @@ collection Researcher {
 
   migrations {
     add .facility
+    add .badgedIn
+    backfill .badgedIn = true
   }
 }
 


### PR DESCRIPTION
We this we can talk about how dynamic we are: as soon as the researcher/practitioner leaves the building the terminal they swipe their badge can flip this flag and they can't access patient records anymore.